### PR TITLE
Refactor the donut data type DonutArc

### DIFF
--- a/src/donuts/AbstractDonut.ts
+++ b/src/donuts/AbstractDonut.ts
@@ -18,7 +18,7 @@
  */
 
 import { DonutParams } from './DonutParams';
-import { DonutNode, DonutDimensions, DonutUtils, DonutArc, DonutTooltip } from './utils/DonutUtils';
+import { DonutNode, DonutDimensions, DonutUtils, TreeNode, DonutTooltip, SimpleNode } from './utils/DonutUtils';
 import { scaleLinear, scaleSqrt, ScaleLinear, ScalePower } from 'd3-scale';
 import { arc, Arc, DefaultArcObject } from 'd3-shape';
 import { select, mouse, ContainerElement } from 'd3-selection';
@@ -62,8 +62,8 @@ export abstract class AbstractDonut {
     this.styleNodes();
   }
 
-  public abstract dataChange(newData: DonutArc): void;
-  public abstract onSelectionChange(selectedArcsList: Array<Array<{ ringName: string, name: string }>>): void;
+  public abstract dataChange(newData: TreeNode): void;
+  public abstract onSelectionChange(selectedArcsList: Array<Array<SimpleNode>>): void;
 
 
 
@@ -103,7 +103,7 @@ export abstract class AbstractDonut {
         if (d.data.size !== undefined && d.data.size !== null) {
           d.value = +d.data.size;
         } else {
-          throw new Error('The node size of ' + d.data.name + ' is not specified');
+          throw new Error('The node size of ' + d.data.fieldValue + ' is not specified');
         }
       })
       .sort((a, b) => b.value - a.value);
@@ -221,11 +221,11 @@ export abstract class AbstractDonut {
    * @param selectedArc Path from the selected arc to the ultimate parent (as an array)
    * @description REMOVES ALL THE NODES OF SAME RING HAVING THE SAME VALUE FROM THE SELECTEDARCSLIST,
    */
-  protected removeAllSimilarNodesOfSameRing(selectedArc: Array<{ ringName: string, name: string }>): void {
+  protected removeAllSimilarNodesOfSameRing(selectedArc: Array<SimpleNode>): void {
     const listNodesToRemove = [];
     for (let i = 0; i < this.donutParams.selectedArcsList.length; i++) {
       const a = this.donutParams.selectedArcsList[i];
-      if (a.length === selectedArc.length && a[0].ringName === selectedArc[0].ringName && a[0].name === selectedArc[0].name) {
+      if (a.length === selectedArc.length && a[0].fieldName === selectedArc[0].fieldName && a[0].fieldValue === selectedArc[0].fieldValue) {
         listNodesToRemove.push(i);
       }
     }
@@ -306,11 +306,11 @@ export abstract class AbstractDonut {
     const arcColorMap = new Map<string, string>();
     this.donutTooltip.nodeParents = new Array<string>();
     hoveredNodeAncestors.forEach(node => {
-      arcColorMap.set(node.data.name, DonutUtils.getNodeColor(node, this.donutParams.donutNodeColorizer));
-      this.donutTooltip.nodeParents.unshift(node.data.name);
+      arcColorMap.set(node.data.fieldValue, DonutUtils.getNodeColor(node, this.donutParams.donutNodeColorizer));
+      this.donutTooltip.nodeParents.unshift(node.data.fieldValue);
     });
     this.donutParams.hoveredNodesEvent.next(arcColorMap);
-    this.donutTooltip.nodeName = hoveredNode.data.name;
+    this.donutTooltip.nodeName = hoveredNode.data.fieldValue;
     this.donutTooltip.nodeCount = hoveredNode.value;
     this.donutTooltip.nodeColor = DonutUtils.getNodeColor(hoveredNode, this.donutParams.donutNodeColorizer);
   }

--- a/src/donuts/DonutParams.ts
+++ b/src/donuts/DonutParams.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { DonutArc, DonutNode, DonutTooltip } from './utils/DonutUtils';
+import { TreeNode, DonutNode, DonutTooltip } from './utils/DonutUtils';
 import { Subject } from 'rxjs';
 import { Tooltip } from '../histograms/utils/HistogramUtils';
 import { ColorGenerator } from '../utils/color-generator';
@@ -32,7 +32,7 @@ export class DonutParams {
   /**
    * @description Data displayed on the donut. Each node's size must be specified
    */
-  public donutData: DonutArc;
+  public donutData: TreeNode;
 
   /**
    * @description Sets the opacity of non-hovered or non-selected nodes.
@@ -47,8 +47,8 @@ export class DonutParams {
   /**
    * @description List of selected nodes.
    */
-  public selectedArcsList: Array<Array<{ ringName: string, name: string }>> =
-    new Array<Array<{ ringName: string, name: string }>>();
+  public selectedArcsList: Array<Array<{ fieldName: string, fieldValue: string }>> =
+    new Array<Array<{ fieldName: string, fieldValue: string }>>();
 
   /**
    * @description Whether the donut is multi-selectable.
@@ -58,8 +58,8 @@ export class DonutParams {
   /**
    * @description Emits the list of selected nodes and the paths to their ultimate parent
    */
-  public selectedNodesEvent: Subject<Array<Array<{ ringName: string, name: string }>>> =
-    new Subject<Array<Array<{ ringName: string, name: string }>>>();
+  public selectedNodesEvent: Subject<Array<Array<{ fieldName: string, fieldValue: string }>>> =
+    new Subject<Array<Array<{ fieldName: string, fieldValue: string }>>>();
 
   /**
    * @description Emits the hovered node and the path to it's parents.

--- a/src/donuts/MultiSelectionDonut.ts
+++ b/src/donuts/MultiSelectionDonut.ts
@@ -18,11 +18,11 @@
  */
 
 import { AbstractDonut } from './AbstractDonut';
-import { DonutNode, DonutArc } from './utils/DonutUtils';
+import { DonutNode, TreeNode, SimpleNode } from './utils/DonutUtils';
 
 export class MultiSelectionDonut extends AbstractDonut {
 
-  public onSelectionChange(selectedArcsList: Array<Array<{ringName: string, name: string}>>) {
+  public onSelectionChange(selectedArcsList: Array<Array<SimpleNode>>) {
     this.donutParams.selectedArcsList = selectedArcsList;
     this.deselectAll();
     this.removeUnExistingNodes();
@@ -30,7 +30,7 @@ export class MultiSelectionDonut extends AbstractDonut {
     this.styleNodes();
   }
 
-  public dataChange(newData: DonutArc): void {
+  public dataChange(newData: TreeNode): void {
     this.donutParams.donutData = newData;
     this.plot();
     this.reapplySelection();

--- a/src/donuts/OneSelectionDonut.ts
+++ b/src/donuts/OneSelectionDonut.ts
@@ -18,11 +18,11 @@
  */
 
 import { AbstractDonut } from './AbstractDonut';
-import { DonutNode, DonutUtils, DonutArc } from './utils/DonutUtils';
+import { DonutNode, DonutUtils, TreeNode, SimpleNode } from './utils/DonutUtils';
 
 export class OneSelectionDonut extends AbstractDonut {
 
-  public dataChange(newData: DonutArc): void {
+  public dataChange(newData: TreeNode): void {
     this.donutParams.donutData = newData;
     this.plot();
     if (this.donutParams.selectedArcsList.length === 1) {
@@ -34,7 +34,7 @@ export class OneSelectionDonut extends AbstractDonut {
     }
   }
 
-  public onSelectionChange(selectedArcsList: Array<Array<{ringName: string, name: string}>>) {
+  public onSelectionChange(selectedArcsList: Array<Array<SimpleNode>>) {
     this.donutParams.selectedArcsList = selectedArcsList;
     if (this.donutParams.selectedArcsList.length === 1) {
       this.deselectAll();

--- a/src/donuts/utils/DonutUtils.ts
+++ b/src/donuts/utils/DonutUtils.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import { MarginModel } from '../../histograms/utils/HistogramUtils';
 import { ColorGenerator } from '../../utils/color-generator';
 import { Selection, BaseType } from 'd3-selection';
 import { HierarchyRectangularNode } from 'd3-hierarchy';
@@ -38,13 +37,18 @@ export interface DonutTooltip {
   nodeColor: string;
 }
 
-export interface DonutArc {
-  name: string;
+export interface TreeNode {
   id: string;
-  ringName: string;
-  isOther: boolean;
+  fieldName: string;
+  fieldValue: string;
   size?: number;
-  children?: Array<DonutArc>;
+  isOther: boolean;
+  children?: Array<TreeNode>;
+}
+
+export interface SimpleNode {
+  fieldName: string;
+  fieldValue: string;
 }
 
 export interface DonutNode extends HierarchyRectangularNode<any> {
@@ -57,12 +61,12 @@ export interface DonutNode extends HierarchyRectangularNode<any> {
 
 export class DonutUtils {
 
-  public static getNode(nodePath: Array<{ringName: string, name: string}>, donutNodes: Array<any>): DonutNode {
+  public static getNode(nodePath: Array<SimpleNode>, donutNodes: Array<any>): DonutNode {
     let count = nodePath.length - 1;
     let nodeToSelect = null;
     for (let i = 0; i < donutNodes.length; i++) {
-      if (donutNodes[i].data.name === nodePath[count].name &&
-        donutNodes[i].data.ringName === nodePath[count].ringName) {
+      if (donutNodes[i].data.fieldValue === nodePath[count].fieldValue &&
+        donutNodes[i].data.fieldName === nodePath[count].fieldName) {
         nodeToSelect = donutNodes[i];
         break;
       }
@@ -72,8 +76,8 @@ export class DonutUtils {
       const children = nodeToSelect.children;
       if (children !== undefined) {
         for (let i = 0; i < children.length; i++) {
-          if (children[i].data.name === nodePath[count].name &&
-            children[i].data.ringName === nodePath[count].ringName) {
+          if (children[i].data.fieldValue === nodePath[count].fieldValue &&
+            children[i].data.fieldName === nodePath[count].fieldName) {
               nodeToSelect = children[i];
               break;
           } else {
@@ -93,23 +97,23 @@ export class DonutUtils {
   public static getNodeColor(d: DonutNode, donutNodeColorizer: ColorGenerator): string {
     if (d.depth > 0) {
       if (donutNodeColorizer) {
-        return donutNodeColorizer.getColor(d.data.name);
+        return donutNodeColorizer.getColor(d.data.fieldValue);
       } else {
-        return this.getHexColorFromString(d.data.name + ':' + d.data.ringName);
+        return this.getHexColorFromString(d.data.fieldValue + ':' + d.data.fieldName);
       }
     } else {
       return '#fff';
     }
   }
 
-  public static getNodePathAsArray(n: DonutNode): Array<{ringName: string, name: string}> {
-    const nodePathAsArray = new Array<{ringName: string, name: string}>();
+  public static getNodePathAsArray(n: DonutNode): Array<{fieldName: string, fieldValue: string}> {
+    const nodePathAsArray = new Array<{fieldName: string, fieldValue: string}>();
     if (n.depth > 0) {
-      nodePathAsArray.push({ringName: n.data.ringName, name: n.data.name});
+      nodePathAsArray.push({fieldName: n.data.fieldName, fieldValue: n.data.fieldValue});
       if (n.parent && n.parent.parent) {
         while (n.parent.parent) {
           n = <DonutNode>n.parent;
-          nodePathAsArray.push({ringName: n.data.ringName, name: n.data.name});
+          nodePathAsArray.push({fieldName: n.data.fieldName, fieldValue: n.data.fieldValue});
         }
       }
     }
@@ -120,7 +124,7 @@ export class DonutUtils {
     const nodePathAsArray = this.getNodePathAsArray(n);
     let path = '';
     nodePathAsArray.forEach(node => {
-      path = node.name + ' > ' + path;
+      path = node.fieldValue + ' > ' + path;
     });
     return path;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export { AbstractSwimlane } from './histograms/swimlanes/AbstractSwimlane';
 export {
   ChartType, DataType, SelectedInputValues, SelectedOutputValues, Position, SwimlaneMode, HistogramUtils
 } from './histograms/utils/HistogramUtils';
-export { DonutArc, DonutNode, DonutDimensions, DonutUtils, DonutTooltip } from './donuts/utils/DonutUtils';
+export { TreeNode, SimpleNode, DonutNode, DonutDimensions, DonutUtils, DonutTooltip } from './donuts/utils/DonutUtils';
 export { AbstractDonut } from './donuts/AbstractDonut';
 export { OneSelectionDonut } from './donuts/OneSelectionDonut';
 export { MultiSelectionDonut } from './donuts/MultiSelectionDonut';


### PR DESCRIPTION
`DonutArc` interface is renamed to `TreeNode`
`ringName` attribute is renamed to `fieldName`
`name` attribute is renamed to `fieldValue`
The other attributes stay the same

Fix #77