### PR TITLE
fix: change round method

### DIFF
--- a/src/donuts/utils/DonutUtils.ts
+++ b/src/donuts/utils/DonutUtils.ts
@@ -151,7 +151,8 @@ export class DonutUtils {
         color: DonutUtils.getNodeColor(n, donutNodeColorizer, keysToColors, colorsSaturationWeight)
       };
       if (n.parent) {
-        tooltipContent.percentage = Math.round(n.data.size / n.parent.data.size * 100).toFixed(2);
+        const num = (n.data.size / n.parent.data.size * 100);
+        tooltipContent.percentage = (Math.round(num * 100) / 100).toString();
       }
       tooltipArray.push(tooltipContent);
       if (n.parent && n.parent.parent) {
@@ -164,7 +165,8 @@ export class DonutUtils {
             color: DonutUtils.getNodeColor(n, donutNodeColorizer, keysToColors, colorsSaturationWeight)
           };
           if (n.parent) {
-            tc.percentage = Math.round(n.data.size / n.parent.data.size * 100).toFixed(2);
+            const num = (n.data.size / n.parent.data.size * 100);
+            tc.percentage =   (Math.round(num * 100) / 100).toString();
           }
           tooltipArray.push(tc);
         }


### PR DESCRIPTION
- Fix gisaia/ARLAS-wui#737

(66379÷150356) * 100 = 44,14788901;
should be eq to 44,15;

![image](https://github.com/gisaia/ARLAS-d3/assets/155989195/ce11ad76-67b3-41f7-934b-ddf126b93d5d)
